### PR TITLE
Add support for Bandcamp to both Platform and APIProvider

### DIFF
--- a/lib/src/platforms.rs
+++ b/lib/src/platforms.rs
@@ -29,6 +29,7 @@ pub enum Platform {
     Anghami,
     Boomplay,
     Audiomack,
+    Bandcamp,
 }
 
 impl FromStr for Platform {
@@ -56,6 +57,7 @@ impl FromStr for Platform {
             "anghami" => Ok(Self::Anghami),
             "boomplay" => Ok(Self::Boomplay),
             "audiomack" => Ok(Self::Audiomack),
+            "bandcamp" => Ok(Self::Bandcamp),
             _ => Err(Self::Err::UnknownPlatform(value.to_string())),
         }
     }
@@ -95,6 +97,7 @@ impl clap::ValueEnum for Platform {
             Self::Anghami,
             Self::Boomplay,
             Self::Audiomack,
+            Self::Bandcamp,
         ]
     }
 
@@ -126,6 +129,7 @@ impl Platform {
             Self::Anghami => "anghami",
             Self::Boomplay => "boomplay",
             Self::Audiomack => "audiomack",
+            Self::Bandcamp => "bandcamp",
         }
     }
 }
@@ -159,6 +163,7 @@ pub enum APIProvider {
     Anghami,
     Boomplay,
     Audiomack,
+    Bandcamp,
 }
 
 impl FromStr for APIProvider {
@@ -182,6 +187,7 @@ impl FromStr for APIProvider {
             "anghami" => Ok(Self::Anghami),
             "boomplay" => Ok(Self::Boomplay),
             "audiomack" => Ok(Self::Audiomack),
+            "bandcamp" => Ok(Self::Bandcamp),
             _ => Err(Self::Err::UnknownAPIProvider(value.to_string())),
         }
     }
@@ -216,6 +222,7 @@ impl APIProvider {
             Self::Anghami => "anghami",
             Self::Boomplay => "boomplay",
             Self::Audiomack => "audiomack",
+            Self::Bandcamp => "bandcamp",
         }
     }
 }


### PR DESCRIPTION
Hi,

I've noticed that even though they do not list it in their API documentation, the response can contain Bandcamp as both a platform and an API provider. This means that I was getting parser error from this library for any track/album that had a Bandcamp release.

This can be tested with for example:
```
odesli get-url https://open.spotify.com/album/1sY6S9koW9A7cwvMybKLnh
```
which resulted in:
```
Failed to get results: Failed to JSON parse the response body: Unknown APIProvider: bandcamp at line 1 column 931
```

This PR adds definitions for it, then everything seems to work fine from my testing.

Thanks for the library!